### PR TITLE
Converted the Argon2Type pseudo-enum to a more pythonic style

### DIFF
--- a/argon2.py
+++ b/argon2.py
@@ -39,6 +39,10 @@ class Argon2Type(object):
     Argon2_i = 1
 
 
+argon2_d = Argon2Type.Argon2_d
+argon2_i = Argon2Type.Argon2_i
+
+
 class Argon2Exception(Exception):
     errors = ("ARGON2_OK", "ARGON2_OUTPUT_PTR_NULL", "ARGON2_OUTPUT_TOO_SHORT", "ARGON2_OUTPUT_TOO_LONG",
               "ARGON2_PWD_TOO_SHORT", "ARGON2_PWD_TOO_LONG", "ARGON2_SALT_TOO_SHORT",


### PR DESCRIPTION
Specifically, since in python flat is better than nested, I pulled the
enum out of the containing class and into the main namespace, this
allows usage with `argon_type=argon2.argon2_i` instead of the existing
`argon_type=argon2.Argon2Type.Argon2_i` which is unnecesarilly verbose.

This change also attemps to be more compliant with python best
practices, by converting to true camel case and converting the first
character of the enum to lowercase.

It maintains compatibility.
